### PR TITLE
 Breaking out the SqlExecutorFactory

### DIFF
--- a/Dapper.Abstractions.Oracle.nuspec
+++ b/Dapper.Abstractions.Oracle.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <authors>$author$</authors>
+    <owners>$owners$</owners>
+    <license type="file">LICENSE.txt</license>    
+    <projectUrl>https://github.com/Tazmainiandevil/Dapper.Abstractions</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>$description$</description>
+    <tags>tazmainiandevil Dapper wrapper dapperwrapper abstractions dapper.abstractions IdbConnection database Oracle testability mock unit testing</tags>
+    <releaseNotes>$releaseNotes$</releaseNotes>
+    <dependencies>
+      <dependency id="Dapper.Abstractions" version="2.0.0" />
+      <dependency id="Oracle.ManagedDataAccess.Core" version="3.21.1" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="LICENSE.txt" target="" />
+    <file src="src\Dapper.Abstractions.Oracle\bin\Release\netstandard2.0\Dapper.Abstractions.Oracle.dll" target="lib\netstandard2.0\Dapper.Abstractions.Oracle.dll" />
+    <file src="src\Dapper.Abstractions.Oracle\bin\Release\net6.0\Dapper.Abstractions.Oracle.dll" target="lib\net6.0\Dapper.Abstractions.Oracle.dll" />
+    <file src="src\Dapper.Abstractions.Oracle\bin\Release\net7.0\Dapper.Abstractions.Oracle.dll" target="lib\net7.0\Dapper.Abstractions.Oracle.dll" />
+  </files>
+</package>


### PR DESCRIPTION
Breaking out the SqlExecutorFactory and adding an OracleExecutorFactory to decouple the abstractions as well as provide another example.